### PR TITLE
Ember 1.13 Upgrade: Remove injection into view and corresponding tests

### DIFF
--- a/addon/initializers/flash-message-queue.js
+++ b/addon/initializers/flash-message-queue.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export function initialize(/* container, application */) {
 
-  ['View', 'Controller', 'Route', 'Component'].forEach(function(classType) {
+  ['Controller', 'Route', 'Component'].forEach(function(classType) {
     Ember[classType].reopen({
       flashMessageQueue: Ember.inject.service(),
 

--- a/tests/acceptance/initializers/ember-flash-messages-test.js
+++ b/tests/acceptance/initializers/ember-flash-messages-test.js
@@ -26,11 +26,10 @@ test('Injections on Ember classes', function(assert) {
     const component = container.lookup('component:test-for-injection');
     const controller = container.lookup('controller:application');
     const route = container.lookup('route:application');
-    const view = container.lookup('view:test-for-injection');
 
-    assert.expect(8);
+    assert.expect(6);
 
-    [component, controller, route, view].forEach(function(instance) {
+    [component, controller, route].forEach(function(instance) {
       const name = instance.get('constructor').toString();
 
       assert.ok(!!instance.get('flashMessageQueue'),

--- a/tests/dummy/app/views/test-for-injection.js
+++ b/tests/dummy/app/views/test-for-injection.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.View.extend();


### PR DESCRIPTION
Deprecate use of views for Ember 1.13
